### PR TITLE
add title and description tags to oracle announcement event kind

### DIFF
--- a/88.md
+++ b/88.md
@@ -117,6 +117,14 @@ attestations respectively.
       "wss://nostr.mutinywallet.com",
       "wss://relay.damus.io"
     ],
+    [
+      "title",
+      "Optional Event Title"
+    ],
+    [
+      "description",
+      "An optional human-readable description of the event which the oracle will attest to, in plain text."
+    ]
   ],
   "pubkey": "97c70a44366a6535c145b333f973ea86dfdc2d7a99da618c40c64705ad98e322",
   "created_at": 1679673265,
@@ -127,6 +135,10 @@ attestations respectively.
 
 The `content` field must be the base64-encoding of a binary-serialized
 [`oracle_annoucement` object](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#the-oracle_annoucement-type).
+
+The optional `title` tag gives observers a short human-readable title with which to display the announcement in cards, hyperlinks, etc. It _should_ be at most 100 characters of UTF8 text. Clients _should_ ignore or truncate titles longer than 100 characters. This tag must NOT be parsed as markdown or HTML.
+
+The optional `description` tag provides a human-readable summary of the real-world event which this announcement is for. The `description` should give observers context, so that they know how the real-world event in question will be reflected in the oracle's final attestation. This tag must NOT be parsed as markdown or HTML.
 
 ### `kind:89`
 


### PR DESCRIPTION
These tags will be necessary for clients to display human readable versions of the oracle announcements.